### PR TITLE
Set File Creation Time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vscode
 Downloads
 json
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.vscode
+Downloads
+json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,26 @@
+{
+  "name": "snapchat-all-memories-downloader",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "moment": {
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.0.tgz",
+      "integrity": "sha512-z6IJ5HXYiuxvFTI6eiQ9dm77uE0gyy1yXNApVHqTcnIKfY9tIwEjlzsZ6u1LQXvVgKeTnv9Xm7NDvJ7lso3MtA=="
+    },
+    "node-addon-api": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.0.2.tgz",
+      "integrity": "sha512-+D4s2HCnxPd5PjjI0STKwncjXTUKKqm74MDMz9OPXavjsGmjkvwgLtA5yoxJUdmpj52+2u+RrXgPipahKczMKg=="
+    },
+    "utimes": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/utimes/-/utimes-4.0.2.tgz",
+      "integrity": "sha512-mE/6X4v+EFbFr+n3jvAH92qc1FKe1t0WIHdUU+pZ8IjkZdJQU1qFS76KmxlfUTZXLyrwvHHmedtLbWXIxE32fw==",
+      "requires": {
+        "node-addon-api": "^3.0.2"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "snapchat-all-memories-downloader",
+  "description": "Script to download all your Snapchat memories",
+  "authors": "ToTheMax <https://github.com/ToTheMax>",
+  "version": "1.0.0",
+  "main": "main.js",
+  "scripts": {
+    "start": "node main.js"
+  },
+  "dependencies": {
+    "moment": "2.29.0",
+    "utimes": "4.0.2"
+  }
+}


### PR DESCRIPTION
This PR adds the ability for the script to extract file creation times from the archive and apply them to the downloaded files (#13). This is helpful because uploading the images to a service like Google Photos will result in the images being placed correctly in the timeline. To do this, I had to use the `utimes` package from npm, which means that users must run `npm install` before they can run this script. Since I'm already using npm, I also added `moment` to make the date parsing a little more safe. 

I have tested this and it seemed to work, but I would have liked to test it more before I am confident in merging. There was weird case in which Snapchat themselves sent files with the wrong dates! The archive itself did not match the dates I saw in my snapchat history. I highly doubt I could bother Snapchat to fix that, since I think they probably made the archive "good enough" to meet law requirements and nothing more.

I haven't added a note to the README about the `npm install` yet, that still needs to be done. Thanks!