### PR TITLE
Remove periods from generated filenames

### DIFF
--- a/main.js
+++ b/main.js
@@ -54,8 +54,7 @@ function main() {
 }
 
 function getFileName(download, fileTime) {
-    // Using . instead of : for time separator because Windows doesn't like it.
-    var filename = fileTime.format("YYYY-MM-DD_HH.mm.ss")
+    var filename = fileTime.format("YYYY-MM-DD_HH-mm-ss")
 
     if (download["Media Type"] == "PHOTO")
         filename += ".jpg";


### PR DESCRIPTION
Pull request to remove periods from the generated filenames. While periods are valid characters to use in filenames, I would suggest moving away from them. Other command line tools (ex. `rclone`) won't always expect them _before_ the file extension and will cause issues or unexpected behavior.