### PR TITLE
Check filenames not already written

### DIFF
--- a/main.js
+++ b/main.js
@@ -32,6 +32,7 @@ const jsonFile =
     !options.f.startsWith("/") && !options.f.startsWith("./")
         ? "./" + options.f
         : options.f;
+var names = [];
 
 // INIT
 try {
@@ -131,7 +132,7 @@ const getDownloadLink = (url, body, fileName, fileTime) =>
 const downloadMemory = (downloadUrl, fileName, fileTime) =>
     new Promise((resolve, reject) => {
         // Check if there already exists a file with the same name/timestamp
-        if (fs.existsSync(outputDir + "/" + fileName)) {
+        if (fs.existsSync(outputDir + "/" + fileName) || names.includes(fileName)) {
             duplicates = 1;
             while (true) {
                 var extensionPos = fileName.lastIndexOf(".");
@@ -141,13 +142,14 @@ const downloadMemory = (downloadUrl, fileName, fileTime) =>
                     duplicates +
                     ")" +
                     fileName.substring(extensionPos, fileName.length);
-                if (fs.existsSync(outputDir + "/" + newFilename)) duplicates++;
+                if (fs.existsSync(outputDir + "/" + newFilename) || names.includes(newFilename)) duplicates++;
                 else {
                     fileName = newFilename;
                     break;
                 }
             }
         }
+        names.push(fileName);
 
         var req = https.get(downloadUrl, function (res) {
             if (res.statusCode == 200) {

--- a/main.js
+++ b/main.js
@@ -32,7 +32,7 @@ const jsonFile =
     !options.f.startsWith("/") && !options.f.startsWith("./")
         ? "./" + options.f
         : options.f;
-var names = [];
+var names = new Set();
 
 // INIT
 try {
@@ -132,7 +132,7 @@ const getDownloadLink = (url, body, fileName, fileTime) =>
 const downloadMemory = (downloadUrl, fileName, fileTime) =>
     new Promise((resolve, reject) => {
         // Check if there already exists a file with the same name/timestamp
-        if (fs.existsSync(outputDir + "/" + fileName) || names.includes(fileName)) {
+        if (fs.existsSync(outputDir + "/" + fileName) || names.has(fileName)) {
             duplicates = 1;
             while (true) {
                 var extensionPos = fileName.lastIndexOf(".");
@@ -142,14 +142,14 @@ const downloadMemory = (downloadUrl, fileName, fileTime) =>
                     duplicates +
                     ")" +
                     fileName.substring(extensionPos, fileName.length);
-                if (fs.existsSync(outputDir + "/" + newFilename) || names.includes(newFilename)) duplicates++;
+                if (fs.existsSync(outputDir + "/" + newFilename) || names.has(newFilename)) duplicates++;
                 else {
                     fileName = newFilename;
                     break;
                 }
             }
         }
-        names.push(fileName);
+        names.add(fileName);
 
         var req = https.get(downloadUrl, function (res) {
             if (res.statusCode == 200) {


### PR DESCRIPTION
Currently, the existing code only uses `fs.existsSync` to check for name conflicts with files that already have been written. However, this doesn't work when you have two files with the same timestamp where both haven't been written yet. In this scenario, they get assigned the same name and one file overwrites the other file. This was causing issues where some files were missing. This PR adds code to check for name conflicts for files that haven't been written yet so this doesn't happen.